### PR TITLE
remove hardcode bg value and update primary color in theme

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -24,7 +24,7 @@ export const RainbowKitCustomConnectButton = () => {
             {(() => {
               if (!connected) {
                 return (
-                  <button className="btn btn-primary rounded-lg bg-[#ff0420]" onClick={openConnectModal} type="button">
+                  <button className="btn btn-primary rounded-lg" onClick={openConnectModal} type="button">
                     Connect wallet
                   </button>
                 );

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
     themes: [
       {
         scaffoldEth: {
-          primary: "#FF0320", // Shows as OP red #FF0420
+          primary: "#FF0420",
           "primary-content": "#ffffff",
           secondary: "#ffffff",
           "secondary-content": "#212638",


### PR DESCRIPTION
## Description

Remove the hardcoded color and update the theme's `primary` color to `#FF0420`

It seems that daisyUI uses converts internally from hex to `hsl` and when Chrome tries to convert the `hsl(353, 100%, 51%)` [which is OP brand color in hsl] in the devtool UI it shows `#FF0522` 

Also If you look at figma and chrome devtools hsl value they both are same : 

| Figma | Chrome | 
|-------| ---------| 
| ![Screenshot 2023-07-27 at 2 02 49 AM](https://github.com/scaffold-eth/OP-RetroPGF3-Discovery-Voting/assets/80153681/a1e68a20-93fa-4323-bdd7-703b3dcbd884) | ![Screenshot 2023-07-27 at 2 03 13 AM](https://github.com/scaffold-eth/OP-RetroPGF3-Discovery-Voting/assets/80153681/6f4c4fcf-95d9-4522-bd8b-e57f1d29a082) | 

So I think we are good to use theme color instead of hardcoding 🙌 (Also visually there is no diff)

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


cc @escottalexander @ZakGriffith 