### PR TITLE
Suggested projects blank when looking at a list, made them responsive…

### DIFF
--- a/packages/nextjs/components/lists/SharedProjects.tsx
+++ b/packages/nextjs/components/lists/SharedProjects.tsx
@@ -48,14 +48,14 @@ const SharedProjects: React.FC<Props> = ({ list }) => {
   };
 
   return (
-    <div className=" border-[#a2aab6] border-2 rounded-3xl gap-10 grid  px-8 py-10">
-      <div className="project__header-container min-w-[320px]">
+    <div className=" border-[#a2aab6] border-2 rounded-3xl gap-10 grid  px-8 py-10 ">
+      <div className="project__header-container min-w-[300px] sm:py-1 ">
         <div className="project__header-container--content">
           <h3 className="text-lg sm:text-2xl font-bold   items-center">
             <span>{projects?.length} Projects -</span>
             <span> {projects?.reduce((sum, p) => sum + p.allocation, 0)} OP Allocated</span>
           </h3>
-          <div className="grid grid-flow-col gap-3 sm:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <CustomProjectButton
               onClick={handleEditModal}
               text="Edit Distribution"
@@ -75,7 +75,7 @@ const SharedProjects: React.FC<Props> = ({ list }) => {
         </div>
       </div>
       <div
-        className="max-h-[500px] pr-2 overflow-y-auto 
+        className="max-h-[500px] pr-2 overflow-y-auto
       scrollbar-thin
       scrollbar-thumb-rounded-full
       scrollbar-thumb-[#E2E8F0]"

--- a/packages/nextjs/components/op/modals/EditDistributionModal.tsx
+++ b/packages/nextjs/components/op/modals/EditDistributionModal.tsx
@@ -84,7 +84,7 @@ const EditDistributionModal: React.FC<Props> = ({ list, onClose }) => {
           <ArrowPathIcon className="h-3 w-3" />
         </CustomProjectButton>
         <div
-          className="max-h-[400px] pr-2 overflow-y-auto 
+          className="max-h-[400px] pr-2 overflow-y-auto
       scrollbar-thin
       scrollbar-thumb-rounded-full
       scrollbar-thumb-OPlightgray"

--- a/packages/nextjs/components/projects/AllProjects.tsx
+++ b/packages/nextjs/components/projects/AllProjects.tsx
@@ -78,7 +78,7 @@ const AllProjects = () => {
             <Spinner />
           </div>
         ) : (
-          <div className="container  mx-auto">
+          <div className="w-full">
             <ProjectsPageHeader
               displayList={displayList}
               titleHeader="Projects"

--- a/packages/nextjs/pages/lists/[listId].tsx
+++ b/packages/nextjs/pages/lists/[listId].tsx
@@ -57,7 +57,7 @@ const ListDetail: NextPage<Props> = ({ list }) => {
   };
 
   return (
-    <div className="mx-auto sm:px-1 md:px-12  mt-12 grid lg:grid-cols-[350px,1fr] gap-12">
+    <div className="container mx-auto sm:px-1 md:px-12  mt-12 grid lg:grid-cols-[350px,1fr] gap-12">
       <YourBallot />
       <div className="w-full">
         <div className="grid mb-3 sm:grid-flow-col items-center">

--- a/packages/nextjs/pages/lists/[listId].tsx
+++ b/packages/nextjs/pages/lists/[listId].tsx
@@ -8,8 +8,6 @@ import { HeartIcon } from "@heroicons/react/24/outline";
 import SharedProjects from "~~/components/lists/SharedProjects";
 import YourBallot from "~~/components/op/projects/YourBallot";
 import { Address } from "~~/components/scaffold-eth";
-import SuggestProjects from "~~/components/shared/SuggestProjects";
-import { useSuggestedProjects } from "~~/hooks/scaffold-eth/useSuggestedProjects";
 import dbConnect from "~~/lib/dbConnect";
 import List from "~~/models/List";
 import { IList } from "~~/types/list";
@@ -26,10 +24,6 @@ interface Props {
 
 const ListDetail: NextPage<Props> = ({ list }) => {
   const [openLikedModal, setOpenLikedModal] = React.useState(false);
-  const tempCategory = list.tags ? list?.tags[0] : undefined;
-  const category = tempCategory && tempCategory[0]?.toUpperCase() + tempCategory?.slice(1);
-  const currentProjectId = list._id;
-  const { suggestedProjects } = useSuggestedProjects(category, currentProjectId);
   const { likes } = list;
   const { address } = useAccount();
   const isLiked = likes?.includes(address ?? "");
@@ -63,9 +57,9 @@ const ListDetail: NextPage<Props> = ({ list }) => {
   };
 
   return (
-    <div className=" mx-auto px-12 mt-12 grid lg:grid-cols-[350px,1fr] gap-12">
+    <div className="mx-auto sm:px-1 md:px-12  mt-12 grid lg:grid-cols-[350px,1fr] gap-12">
       <YourBallot />
-      <div className="">
+      <div className="w-full">
         <div className="grid mb-3 sm:grid-flow-col items-center">
           <h3 className="text-2xl font-bold">{list.name}</h3>
           <div className="grid grid-flow-col gap-4 w-fit sm:w-full sm:justify-end relative">
@@ -114,24 +108,16 @@ const ListDetail: NextPage<Props> = ({ list }) => {
           <Address address={list.creator} />
         </div>
         <div className="mt-8">
-          <h4 className="text-[#68778D] text-lg">🧑‍💻 DESCRIPTION</h4>
-          <p>{list.description}</p>
+          <h4 className="text-[#68778D] text-lg ">🧑‍💻 DESCRIPTION</h4>
+          <p className="px-3 text-justify">{list.description}</p>
         </div>
         <div className="mt-8">
           <h4 className="text-[#68778D] text-lg">📊 IMPACT EVALUATION</h4>
-          <p>{list.impactEvaluation}</p>
-          {/* <button className="grid grid-flow-col w-fit items-center rounded-full px-4 gap-2 border-[1px] border-[#CBD5E0] ">
-            <div className="rounded-full p-1 bg-[#E2E8F0]">
-              <DocumentIcon className="w-6 h-6 text-[#68778D]" />
-            </div>
-            <p className=" ">impact Evaluation</p>
-            <ArrowTopRightOnSquareIcon className="text-[#68778D] w-6 h-6" />
-          </button> */}
+          <p className="px-3 text-justify">{list.impactEvaluation}</p>
         </div>
 
-        <div className="mt-16">
+        <div className="mt-16 mb-32">
           <SharedProjects list={list} />
-          <SuggestProjects suggestedProjects={suggestedProjects} />
         </div>
       </div>
     </div>

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -132,7 +132,7 @@ input[type="number"] {
     max-width: 99%;
 }
 
-.project__card-container_btn {
+project__card-container_btn {
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
Suggested projects blank when looking at a list, made them responsive with several changes, and removed unused code.
## Description
1.  Remove Suggested Projects component and utils not used for this page
2. Made List details responsive
3. Change the CustomProjectButton flow to render underneath each other for small devices
4. Add style for description and impact sections 
3. Test it and it worked.
 
## Additional Information
- [yes] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [yes] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
## Related Issues
List View Issues #165

Your ENS/address: Coderxyz.eth