### PR TITLE
Add borders to list icons

### DIFF
--- a/packages/nextjs/components/lists/SharedProjects.tsx
+++ b/packages/nextjs/components/lists/SharedProjects.tsx
@@ -94,7 +94,7 @@ const SharedProjects: React.FC<Props> = ({ list }) => {
                   height={"80"}
                   width={"80"}
                   src={`${project?.profileImageUrl ? project.profileImageUrl : "/assets/gradient-bg.png"}`}
-                  className="w-full rounded-xl"
+                  className="w-full rounded-xl border-2 border-gray-300"
                 />
               </div>
               <div className="">


### PR DESCRIPTION
Adds the same small border when viewing a list that we use when viewing a ballot or projects in the list view.